### PR TITLE
Support JSON output format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,11 +38,21 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		format, err := cmd.Flags().GetString("format")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		formatter, found := internal.Formatters[format]
+		if !found {
+			log.Fatalf("formatter %q is not supported", format)
+		}
+
 		if len(args) == 0 {
 			cmd.Help()
 			os.Exit(1)
 		} else {
-			internal.Main(args[0], showData, showAll, limit, processes)
+			internal.Main(args[0], showData, showAll, limit, processes, formatter)
 		}
 	},
 }
@@ -54,9 +64,10 @@ func Execute() {
 	rootCmd.PersistentFlags().Bool("show-all", false, "Show all matches")
 	rootCmd.PersistentFlags().Int("sample-size", 10000, "Sample size")
 	rootCmd.PersistentFlags().Int("processes", 1, "Processes")
+	rootCmd.PersistentFlags().String("format", "text", "Export format")
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		formatter, found := internal.Formatters[format]
+		newFormatter, found := internal.Formatters[format]
 		if !found {
 			log.Fatalf("formatter %q is not supported", format)
 		}
@@ -52,7 +52,7 @@ var rootCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		} else {
-			internal.Main(args[0], showData, showAll, limit, processes, formatter)
+			internal.Main(args[0], showData, showAll, limit, processes, newFormatter(os.Stdout))
 		}
 	},
 }

--- a/internal/format.go
+++ b/internal/format.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// Format defines the interface used to deliver results to the end user.
+type Formatter interface {
+	// PrintMatches formats and prints the matches to `writer`.
+	PrintMatches(
+		writer io.Writer, matches []ruleMatch,
+		showData bool, showAll bool, rowKind string,
+	) error
+}
+
+// Formatters holds available formatters
+var Formatters = map[string]Formatter{
+	"text": TextFormatter{},
+	"json": JSONFormatter{},
+}
+
+// TextFormatter prints the result as human readable text.
+type TextFormatter struct{}
+
+func (f TextFormatter) PrintMatches(
+	writer io.Writer, matchList []ruleMatch,
+	showData bool, showAll bool, rowStr string,
+) error {
+	// print matches for table
+	for _, match := range matchList {
+		if showAll || match.Confidence != "low" {
+			var description string
+
+			count := len(match.MatchedData)
+			if match.MatchType == "name" {
+				description = fmt.Sprintf("possible %s (name match)", match.DisplayName)
+			} else {
+				str := pluralize(count, rowStr)
+				if match.Confidence == "low" {
+					str = str + ", low confidence"
+				}
+				description = fmt.Sprintf("found %s (%s)", match.DisplayName, str)
+			}
+
+			yellow := color.New(color.FgYellow).SprintFunc()
+			fmt.Fprintf(writer, "%s %s\n", yellow(match.Identifier+":"), description)
+
+			if showData {
+				v := unique(match.MatchedData)
+				if len(v) > 0 && showData {
+					if len(v) > 50 {
+						v = v[0:50]
+					}
+
+					for i, v2 := range v {
+						v[i] = space.ReplaceAllString(v2, " ")
+					}
+					sort.Strings(v)
+					fmt.Fprintln(writer, "    "+strings.Join(v, ", "))
+				}
+				fmt.Fprintln(writer, "")
+			}
+		}
+	}
+
+	return nil
+}
+
+// JSONFormatter prints the result as a JSON object.
+type JSONFormatter struct{}
+
+type jsonEntry struct {
+	Name        string `json:"name"`
+	Confidence  string `json:"confidence"`
+	Identifier  string `json:"identifier"`
+	Description string `json:"description"`
+}
+
+type jsonEntryWithMatches struct {
+	jsonEntry
+
+	Matches      []string `json:"matches"`
+	MatchesCount int      `json:"matches_count"`
+}
+
+func (f JSONFormatter) PrintMatches(
+	writer io.Writer, matchList []ruleMatch,
+	showData bool, showAll bool, rowStr string,
+) error {
+	encoder := json.NewEncoder(writer)
+
+	for _, match := range matchList {
+		if showAll || match.Confidence != "low" {
+			var description string
+
+			count := len(match.MatchedData)
+			if match.MatchType == "name" {
+				description = fmt.Sprintf("possible %s (name match)", match.DisplayName)
+			} else {
+				str := pluralize(count, rowStr)
+				if match.Confidence == "low" {
+					str = str + ", low confidence"
+				}
+				description = fmt.Sprintf("found %s (%s)", match.DisplayName, str)
+			}
+
+			entry := jsonEntry{
+				Name:        match.DisplayName,
+				Confidence:  match.Confidence,
+				Identifier:  match.Identifier,
+				Description: description,
+			}
+
+			if showData {
+				v := unique(match.MatchedData)
+				if len(v) > 0 {
+					if len(v) > 50 {
+						v = v[0:50]
+					}
+
+					for i, v2 := range v {
+						v[i] = space.ReplaceAllString(v2, " ")
+					}
+					sort.Strings(v)
+
+					err := encoder.Encode(jsonEntryWithMatches{
+						jsonEntry:    entry,
+						Matches:      v,
+						MatchesCount: len(v),
+					})
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				err := encoder.Encode(entry)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 
-	"github.com/deckarep/golang-set"
-	"github.com/fatih/color"
+	mapset "github.com/deckarep/golang-set"
 )
 
 type nameRule struct {
@@ -245,45 +243,6 @@ func pluralize(count int, singular string) string {
 	return fmt.Sprintf("%d %s", count, singular)
 }
 
-func printMatchList(matchList []ruleMatch, showData bool, showAll bool, rowStr string) {
-	// print matches for table
-	for _, match := range matchList {
-		if showAll || match.Confidence != "low" {
-			var description string
-
-			count := len(match.MatchedData)
-			if match.MatchType == "name" {
-				description = fmt.Sprintf("possible %s (name match)", match.DisplayName)
-			} else {
-				str := pluralize(count, rowStr)
-				if match.Confidence == "low" {
-					str = str + ", low confidence"
-				}
-				description = fmt.Sprintf("found %s (%s)", match.DisplayName, str)
-			}
-
-			yellow := color.New(color.FgYellow).SprintFunc()
-			fmt.Printf("%s %s\n", yellow(match.Identifier+":"), description)
-
-			if showData {
-				v := unique(match.MatchedData)
-				if len(v) > 0 && showData {
-					if len(v) > 50 {
-						v = v[0:50]
-					}
-
-					for i, v2 := range v {
-						v[i] = space.ReplaceAllString(v2, " ")
-					}
-					sort.Strings(v)
-					fmt.Println("    " + strings.Join(v, ", "))
-				}
-				fmt.Println("")
-			}
-		}
-	}
-}
-
 func showLowConfidenceMatchHelp(matchList []ruleMatch) {
 	lowConfidenceMatches := []ruleMatch{}
 	for _, match := range matchList {
@@ -292,11 +251,11 @@ func showLowConfidenceMatchHelp(matchList []ruleMatch) {
 		}
 	}
 	if len(lowConfidenceMatches) > 0 {
-		fmt.Println("Also found " + pluralize(len(lowConfidenceMatches), "low confidence match") + ". Use --show-all to view them")
+		fmt.Fprintln(os.Stderr, "Also found "+pluralize(len(lowConfidenceMatches), "low confidence match")+". Use --show-all to view them")
 	}
 }
 
 func abort(err error) {
-	fmt.Println(err)
+	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -46,7 +46,7 @@ func Main(urlStr string, showData bool, showAll bool, limit int, processes int, 
 					// fmt.Println("Scanning " + file + "...\n")
 					matchedValues, count := adapter.FindFileMatches(file)
 					fileMatchList := checkMatches(file, matchedValues, count, true)
-					err := formatter.PrintMatches(os.Stdout, fileMatchList, showData, showAll, "line")
+					err := formatter.AddMatches(fileMatchList, showData, showAll, "line")
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -84,7 +84,7 @@ func Main(urlStr string, showData bool, showAll bool, limit int, processes int, 
 					queryMutex.Unlock()
 
 					tableMatchList := checkTableData(t, columnNames, columnValues)
-					err := formatter.PrintMatches(os.Stdout, tableMatchList, showData, showAll, "row")
+					err := formatter.AddMatches(tableMatchList, showData, showAll, "row")
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -101,6 +101,11 @@ func Main(urlStr string, showData bool, showAll bool, limit int, processes int, 
 	}
 
 	wg.Wait()
+
+	err := formatter.Flush()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "formatting data failed: ", err)
+	}
 
 	if len(matchList) > 0 {
 		if showData {


### PR DESCRIPTION
Hi @ankane !

I did an initial implementation of multiple formatters support, the list of changes is the following:

- Added a `Formatter` interface to abstract data formatters.
- Added a `format` flag to to choose a format (default: `text`).
- Log are printed to stderr so a user can isolate the results of the scan from
  the log messages.

The text format output is unaffected except for log messages going to `stderr`. 

The JSON format has the following output:

```sh
$ pdscan --format json 'postgres:///var/run/postgresql/opflow_development'
Found 22 tables to scan, sampling 10000 rows from each...

{"name":"emails","confidence":"high","identifier":"public.users.email","description":"found emails (21 rows)"}
{"name":"last names","confidence":"medium","identifier":"public.users.lastname","description":"possible last names (name match)"}

Use --show-data to view data
```

I wanted to have an initial implementation before refining it any further but there is already a few questions that need answering:

- Output format is 1 json object per match.

  This is because it was the simplest to implement, otherwise it would need to support either gathering all results  before formatting can happen or make the formatters stateful.

  Some external tools might be able to consume that output more easily as they can read one JSON object per line output by `pdscan`.

  I would like to hear about others opinions on this, but at the moment it works nicely for what I need to do.

- Error handling in `internal/main.go` should be done.

  Because formatters can fail, `pdscan` should report  those errors. The processing of table matches is currently done concurrently  so it would require to gather encoding errors before reporting them to the user or abort processing entirely.

  Again I would like to hear other's opinions about this design choice.

I hope you appreciate the contribution and that we can work together towards seeing this new feature included in `pdscan`.

Cheers,

Paul