### PR TITLE
Refactor matching logic to capture all regex and token matches

### DIFF
--- a/internal/match_finder.go
+++ b/internal/match_finder.go
@@ -55,16 +55,21 @@ func NewMatchFinder(matchConfig *MatchConfig) MatchFinder {
 // extract values and index in a later step if needed (if --show-data is passed)
 func (a *MatchFinder) Scan(v string, index int) {
 	for i, rule := range a.matchConfig.RegexRules {
-		if rule.Regex.MatchString(v) {
-			a.MatchedValues[i] = append(a.MatchedValues[i], MatchLine{index, v})
+		matches := rule.Regex.FindAllString(v, -1)
+		if len(matches) > 0 {
+			for _, match := range matches {
+				a.MatchedValues[i] = append(a.MatchedValues[i], MatchLine{index, match})
+			}
 		}
 	}
 
 	if len(a.matchConfig.TokenRules) > 0 {
 		tokens := tokenizer.Split(strings.ToLower(v), -1)
 		for i, rule := range a.matchConfig.TokenRules {
-			if anyMatches(rule, tokens) {
-				a.TokenValues[i] = append(a.TokenValues[i], MatchLine{index, v})
+			for _, token := range tokens {
+				if anyMatches(rule, []string{token}) {
+					a.TokenValues[i] = append(a.TokenValues[i], MatchLine{index, token})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Motivation**

My database tables, from a drupal, have html code with one or several emails. With this use case, the output with `--show-data` shows the raw output (whole line), not just matches.

I propose these changes to generate a new release to fix this bug.

**Changes**:

- Updated regex matching to capture all matching substrings, not just the whole line.
- Modified token matching to iterate through each token individually and capture all matching tokens.
- Stores all matching regex substrings and tokens in the respective match values.

**Outputs**

Before the change (random text):

```json
{
  "identifier": "db.view_bookings_items.comment",
  "name": "email",
  "match_type": "value",
  "confidence": "high",
  "matches": [
    "Another teacher will accompany:\nJohn Smith\njohn.smith@newschool.edu",
    "This reservation was made by the School coordinator to record the scheduled activity and send the link to the satisfaction survey once it has been completed. If you have any questions, please send an email to school@education.org",
    "Good morning,\nI spoke with the workshop organizers, and they asked me to request it again with the correct level.\nApologies for any inconvenience this may cause.\nBest regards,\nEmily Roberts\nemily.roberts@university.edu",
    "I would like to know what prior knowledge we should focus on before attending the workshop. \nBest regards,\nDaniel Brown\ndaniel.brown@telerural.com\nRiverwood High School",
    "Hello, we are not ready to make the reservation yet, we would like to request information \nWe would like to know if there is any control over the activities that are conducted. What kind of activities are carried out? Or is it only theoretical explanation?\ncontact: carl.d@newschool.org\nThank you",
    "Westbrook Institute\nmjferris@westbrook.edu\nwestbrookinstitute@edu.org",
    "Westbrook Institute\npaulawashington@westbrook.edu\nwestbrookinstitute@edu.org",
    "Westbrook Institute:  paulawashington@westbrook.edu\nwestbrookinstitute@edu.org",
    "Westbrook Institute:\npaulawashington@westbrook.edu\nwestbrookinstitute@edu.org",
    "Alternatively, you can contact alex.martinez@globaledu.net",
    "Another teacher might be attending. \nYou can also contact j.davis@culturalcentre.org",
    "Puri Lopez:             jlopez@edu.org\nMaria Joseph Vidal     mvideval@edu.org\nWestbrook Institute   123456789",
    "Since the activity became available after the lottery, I would like to register them. These are 4th-grade students with a high level. Although the activity is designed for 1st-year college students, I believe we can prepare them in advance. We have enough time until March to cover the required prior contents.\n\nBest regards,\n\nDavid Garcia\nno_reply@school.com\nPhone. 123456789\nRiverwood High School\n\n",
    "Send a copy of notifications to james.torres@school.org"
  ],
  "matches_count": 14
}
```

After the change:

```json
{
  "identifier": "db.view_bookings_items.comment",
  "name": "email",
  "match_type": "value",
  "confidence": "high",
  "matches": [
    "alex.martinez@globaledu.net",
    "john.smith@newschool.edu",
    "emily.roberts@university.edu",
    "j.davis@culturalcentre.org",
    "james.torres@school.org",
    "escolab@education.org",
    "paulawashington@westbrook.edu",
    "westbrookinstitute@edu.org",
    "mjferris@westbrook.edu",
    "jlopez@edu.org",
    "mvideval@edu.org",
    "paulawashington@westbrook.edu",
    "daniel.brown@telerural.com",
    "carl.d@newschool.org"
  ],
  "matches_count": 14
}
```